### PR TITLE
feat: Add basic retry mechanism for failed segments

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -9,3 +9,7 @@ export const SEGMENT_STARTING_DOWNLOAD = "Segments downloading";
 export const SEGMENT_STICHING = "Stiching segments";
 export const JOB_FINISHED = "Ready for download";
 export const SEGMENT_CHUNK_SIZE = 10;
+
+export const SEGMENT_RETRY_ATTEMPTS = 10;
+
+export const SEGMENT_RETRY_DELAY = 100; // ms


### PR DESCRIPTION
Add retries for failed segments when the download fails with 5xx HTTP errors.